### PR TITLE
adding more null checks for simptip selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-form-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Utility for validating forms",
   "main": "js-form-validator.ts",
   "scripts": {

--- a/src/js-form-validator.ts
+++ b/src/js-form-validator.ts
@@ -64,8 +64,11 @@ export class FormValidator {
     
     if (valid > 0) {
       if (null === inputId) {
+        const st = wrap.querySelector('[class^="simptip"]');
         wrap.classList.remove('error');
-        wrap.querySelector('[class^="simptip"]').removeAttribute('data-tooltip');
+
+        if (st !== null)
+          st.removeAttribute('data-tooltip');
 
         if (input.getAttribute('data-show_success') !== 'false')
           wrap.classList.add('approved');
@@ -127,11 +130,14 @@ export class FormValidator {
   public static setInputError(input: HTMLElement, errorMsg: string): void {
     if (undefined === input || null === input) return;
 
-    const wrap = closest(input, '.input-wrap');
+    const wrap = closest(input, '.input-wrap'),
+          wrapTip = wrap.querySelector('[class^="simptip"]');
     
-    wrap.querySelector('[class^="simptip"]').setAttribute('data-tooltip', errorMsg);
     wrap.classList.add('error');
     wrap.classList.remove('approved');
+
+    if (wrapTip !== null)
+      wrapTip.setAttribute('data-tooltip', errorMsg);
   }
 
   /**


### PR DESCRIPTION
These checks are needed for forms that aren't using completely the same layout as expected for the form validator.