### PR TITLE
Phone type block letters

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,20 @@
+module.exports = function (config) {
+    config.set({
+        frameworks: ['systemjs', 'qunit'],
+        files: [
+        'dist/*.test.js',
+        { pattern: 'dist/**/*!(.test).js', included: false }
+        ],
+        plugins: ['karma-systemjs', 'karma-qunit', 'karma-chrome-launcher'],
+        systemjs: {
+        configFile: 'system.conf.js'
+        },
+        browsers: ['Chrome'],
+        browserNoActivityTimeout: 15000,
+        browserDisconnectTolerance: 10,
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: true,
+        concurrency: Infinity
+    });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-form-validator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Utility for validating forms",
   "main": "js-form-validator.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^2.3.3"
   },
   "jspm": {
-    "main": "dist/js-form-validator.ts",
+    "main": "src/js-form-validator.ts",
     "directories": {
       "baseURL": "src",
       "lib": "src",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,14 @@
   },
   "homepage": "https://github.com/GTMSportswear/js-form-validator#readme",
   "devDependencies": {
+    "@types/qunit": "^2.0.31",
     "jspm": "^0.16.53",
-    "systemjs": "^0.20.12",
+    "karma": "^1.7.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-qunit": "^1.2.1",
+    "karma-systemjs": "^0.16.0",
+    "qunitjs": "^2.3.3",
+    "systemjs": "^0.19.40",
     "traceur": "0.0.111",
     "tslint": "^5.3.2",
     "typescript": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "^2.3.3"
   },
   "jspm": {
-    "main": "src/js-form-validator.ts",
+    "main": "dist/js-form-validator.ts",
     "directories": {
       "baseURL": "src",
       "lib": "src",

--- a/src/js-form-validator.test.ts
+++ b/src/js-form-validator.test.ts
@@ -1,0 +1,55 @@
+import { FormValidator } from './js-form-validator';
+
+let inputWrap: HTMLElement;
+let inputElement: HTMLInputElement;
+let simptip: HTMLElement;
+
+QUnit.module('FormValidator', {
+  beforeEach: () => {
+    inputWrap = document.createElement('div');
+    inputWrap.classList.add('input-wrap');
+
+    inputElement = document.createElement('input');
+    simptip = document.createElement('p');
+    simptip.classList.add('simptip');
+
+    inputWrap.appendChild(inputElement);
+    inputWrap.appendChild(simptip);
+  }
+});
+
+QUnit.test('should pass phone validation with 7 digits', assert => {
+  inputElement.setAttribute('type', 'tel');
+  inputElement.setAttribute('data-validate', 'phone');
+  inputElement.value = '1234567';
+
+  assert.equal(FormValidator.Validate(inputElement), true);
+});
+
+QUnit.test('should pass phone validation with 10 digits', assert => {
+  inputElement.setAttribute('type', 'tel');
+  inputElement.setAttribute('data-validate', 'phone');
+  inputElement.value = '1234567890';
+
+  assert.equal(FormValidator.Validate(inputElement), true);
+});
+
+QUnit.test('should fail phone validation without 7 or 10 digits', assert => {
+  inputElement.setAttribute('type', 'tel');
+  inputElement.setAttribute('data-validate', 'phone');
+  inputElement.value = '12345678';
+
+  assert.equal(FormValidator.Validate(inputElement), false);
+
+  inputElement.value = '123456';
+
+  assert.equal(FormValidator.Validate(inputElement), false);
+});
+
+QUnit.test('should pass phone validation with 10 digits and characters', assert => {
+  inputElement.setAttribute('type', 'tel');
+  inputElement.setAttribute('data-validate', 'phone');
+  inputElement.value = '(123) 456-7890';
+
+  assert.equal(FormValidator.Validate(inputElement), true);
+});

--- a/src/js-form-validator.ts
+++ b/src/js-form-validator.ts
@@ -1,4 +1,4 @@
-import { closest } from './github/gtmsportswear/js-utilities@1.0.0/js-utilities';
+import { closest } from './github/GTMSportswear/js-utilities@1.0.0/js-utilities';
 
 export class FormValidator {
   /**
@@ -313,7 +313,7 @@ export class FormValidator {
       case 'phone':
         if (!allowEmpty && !value.length) return -1;
         const digits = value.match(/\d+/g);
-        status = /^(?=(?:.{7}|.{10})$)[0-9]*$/.test(digits) ? 1 : 0;
+        status = digits.length > 0 && /^(?=(?:.{7}|.{10})$)[0-9]*$/.test(digits.join('')) ? 1 : 0;
         break;
 
       case 'file':

--- a/src/js-form-validator.ts
+++ b/src/js-form-validator.ts
@@ -312,9 +312,8 @@ export class FormValidator {
 
       case 'phone':
         if (!allowEmpty && !value.length) return -1;
-        let vals = value.split('x');
-        value = vals.join('x').replace(/^1/, ''); // remove leading 1 if added, only for US
-        status = /^[0-9\-\+\s\(\)]{7,16}$/.test(value) ? 1 : 0;
+        const digits = value.match(/\d+/g);
+        status = /^(?=(?:.{7}|.{10})$)[0-9]*$/.test(digits) ? 1 : 0;
         break;
 
       case 'file':

--- a/src/js-form-validator.ts
+++ b/src/js-form-validator.ts
@@ -313,10 +313,8 @@ export class FormValidator {
       case 'phone':
         if (!allowEmpty && !value.length) return -1;
         let vals = value.split('x');
-        for (let i = 0, l = vals.length; i < l; i++)
-          vals[i] = vals[i].replace(/\D/g, '');
         value = vals.join('x').replace(/^1/, ''); // remove leading 1 if added, only for US
-        status = /^[0-9x]{7,16}$/.test(value) ? 1 : 0;
+        status = /^[0-9\-\+\s\(\)]{7,16}$/.test(value) ? 1 : 0;
         break;
 
       case 'file':

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,72 @@
+{
+  "rules": {
+    "class-name": true,
+    "comment-format": [false, "check-space"],
+    "curly": false,
+    "eofline": true,
+    "forin": true,
+    "indent": [true, "spaces"],
+    "label-position": true,
+    "label-undefined": true,
+    "max-line-length": [false, 200],
+    "member-access": true,
+    "member-ordering": [true,
+      "public-before-private",
+      "static-before-instance",
+      "variables-before-functions"
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-key": true,
+    "no-duplicate-variable": true,
+    "no-empty": true,
+    "no-eval": true,
+    "no-inferrable-types": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": false,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "no-unreachable": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [true,
+      "check-open-brace",
+      "check-whitespace"
+    ],
+    "quotemark": [true, "single", "avoid-escape"],
+    "radix": true,
+    "semicolon": true,
+    "trailing-comma": [true, {
+      "singleline": "never",
+      "multiline": "never"
+    }],
+    "triple-equals": [true, "allow-null-check"],
+    "typedef-whitespace": [true, {
+      "call-signature": "nospace",
+      "index-signature": "nospace",
+      "parameter": "nospace",
+      "property-declaration": "nospace",
+      "variable-declaration": "nospace"
+    }],
+    "variable-name": false,
+    "whitespace": [true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ]
+  }
+}


### PR DESCRIPTION
This fixes an issue where the `input` would accept letters and then the validation would parse them out before going against the regex pattern. This was allowing the input to accept values that were between 7 and 16 characters, but still contained letters. I also updated the regex to accept digits, hyphens, plus, spaces, and parenthesis.